### PR TITLE
Two bug fixes

### DIFF
--- a/src/main/java/org/opensearch/ad/ml/CheckpointDao.java
+++ b/src/main/java/org/opensearch/ad/ml/CheckpointDao.java
@@ -480,7 +480,8 @@ public class CheckpointDao {
                 if (initResponse.isAcknowledged()) {
                     clientUtil.<BulkRequest, BulkResponse>execute(BulkAction.INSTANCE, request, listener);
                 } else {
-                    throw new RuntimeException("Creating checkpoint with mappings call not acknowledged.");
+                    // create index failure. Notify callers using listener.
+                    listener.onFailure(new RuntimeException("Creating checkpoint with mappings call not acknowledged."));
                 }
             }, exception -> {
                 if (ExceptionsHelper.unwrapCause(exception) instanceof ResourceAlreadyExistsException) {

--- a/src/main/java/org/opensearch/ad/model/AnomalyResult.java
+++ b/src/main/java/org/opensearch/ad/model/AnomalyResult.java
@@ -76,6 +76,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
     public static final String ENTITY_FIELD = "entity";
     public static final String USER_FIELD = "user";
     public static final String TASK_ID_FIELD = "task_id";
+    public static final String MODEL_ID_FIELD = "model_id";
 
     private final String detectorId;
     private final String taskId;
@@ -88,9 +89,20 @@ public class AnomalyResult implements ToXContentObject, Writeable {
     private final Instant executionStartTime;
     private final Instant executionEndTime;
     private final String error;
-    private final List<Entity> entity;
+    private final Entity entity;
     private User user;
     private final Integer schemaVersion;
+    /*
+     * model id for easy aggregations of entities. The front end needs to query
+     * for entities ordered by the descending order of anomaly grades and the
+     * number of anomalies. After supporting multi-category fields, it is hard
+     * to write such queries since the entity information is stored in a nested
+     * object array. Also, the front end has all code/queries/ helper functions
+     * in place to rely on a single key per entity combo. This PR adds model id
+     * to anomaly result to help the transition to multi-categorical field less
+     * painful.
+     */
+    private final String modelId;
 
     public AnomalyResult(
         String detectorId,
@@ -134,7 +146,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         Instant executionStartTime,
         Instant executionEndTime,
         String error,
-        List<Entity> entity,
+        Entity entity,
         User user,
         Integer schemaVersion
     ) {
@@ -152,7 +164,8 @@ public class AnomalyResult implements ToXContentObject, Writeable {
             error,
             entity,
             user,
-            schemaVersion
+            schemaVersion,
+            null
         );
     }
 
@@ -168,9 +181,10 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         Instant executionStartTime,
         Instant executionEndTime,
         String error,
-        List<Entity> entity,
+        Entity entity,
         User user,
-        Integer schemaVersion
+        Integer schemaVersion,
+        String modelId
     ) {
         this.detectorId = detectorId;
         this.taskId = taskId;
@@ -186,6 +200,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         this.entity = entity;
         this.user = user;
         this.schemaVersion = schemaVersion;
+        this.modelId = modelId;
     }
 
     public AnomalyResult(StreamInput input) throws IOException {
@@ -204,11 +219,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         this.executionEndTime = input.readInstant();
         this.error = input.readOptionalString();
         if (input.readBoolean()) {
-            int entitySize = input.readVInt();
-            this.entity = new ArrayList<>(entitySize);
-            for (int i = 0; i < entitySize; i++) {
-                entity.add(new Entity(input));
-            }
+            this.entity = new Entity(input);
         } else {
             this.entity = null;
         }
@@ -219,6 +230,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         }
         this.schemaVersion = input.readInt();
         this.taskId = input.readOptionalString();
+        this.modelId = input.readOptionalString();
     }
 
     @Override
@@ -254,13 +266,16 @@ public class AnomalyResult implements ToXContentObject, Writeable {
             xContentBuilder.field(ERROR_FIELD, error);
         }
         if (entity != null) {
-            xContentBuilder.field(ENTITY_FIELD, entity.toArray());
+            xContentBuilder.field(ENTITY_FIELD, entity);
         }
         if (user != null) {
             xContentBuilder.field(USER_FIELD, user);
         }
         if (taskId != null) {
             xContentBuilder.field(TASK_ID_FIELD, taskId);
+        }
+        if (modelId != null) {
+            xContentBuilder.field(MODEL_ID_FIELD, modelId);
         }
         return xContentBuilder.endObject();
     }
@@ -276,10 +291,11 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         Instant executionStartTime = null;
         Instant executionEndTime = null;
         String error = null;
-        List<Entity> entityList = null;
+        Entity entity = null;
         User user = null;
         Integer schemaVersion = CommonValue.NO_SCHEMA_VERSION;
         String taskId = null;
+        String modelId = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -321,11 +337,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
                     error = parser.text();
                     break;
                 case ENTITY_FIELD:
-                    entityList = new ArrayList<>();
-                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
-                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
-                        entityList.add(Entity.parse(parser));
-                    }
+                    entity = Entity.parse(parser);
                     break;
                 case USER_FIELD:
                     user = User.parse(parser);
@@ -335,6 +347,9 @@ public class AnomalyResult implements ToXContentObject, Writeable {
                     break;
                 case TASK_ID_FIELD:
                     taskId = parser.text();
+                    break;
+                case MODEL_ID_FIELD:
+                    modelId = parser.text();
                     break;
                 default:
                     parser.skipChildren();
@@ -353,9 +368,10 @@ public class AnomalyResult implements ToXContentObject, Writeable {
             executionStartTime,
             executionEndTime,
             error,
-            entityList,
+            entity,
             user,
-            schemaVersion
+            schemaVersion,
+            modelId
         );
     }
 
@@ -378,7 +394,8 @@ public class AnomalyResult implements ToXContentObject, Writeable {
             && Objects.equal(getExecutionStartTime(), that.getExecutionStartTime())
             && Objects.equal(getExecutionEndTime(), that.getExecutionEndTime())
             && Objects.equal(getError(), that.getError())
-            && Objects.equal(getEntity(), that.getEntity());
+            && Objects.equal(getEntity(), that.getEntity())
+            && Objects.equal(getModelId(), that.getModelId());
     }
 
     @Generated
@@ -397,7 +414,8 @@ public class AnomalyResult implements ToXContentObject, Writeable {
                 getExecutionStartTime(),
                 getExecutionEndTime(),
                 getError(),
-                getEntity()
+                getEntity(),
+                getModelId()
             );
     }
 
@@ -417,6 +435,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
             .append("executionEndTime", executionEndTime)
             .append("error", error)
             .append("entity", entity)
+            .append("modelId", modelId)
             .toString();
     }
 
@@ -464,8 +483,23 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         return error;
     }
 
-    public List<Entity> getEntity() {
+    public Entity getEntity() {
         return entity;
+    }
+
+    public String getModelId() {
+        return modelId;
+    }
+
+    /**
+     * Anomaly result index consists of overwhelmingly (99.5%) zero-grade non-error documents.
+     * This function exclude the majority case.
+     * @return whether the anomaly result is important when the anomaly grade is not 0
+     * or error is there.
+     */
+    public boolean isHighPriority() {
+        // AnomalyResult.toXContent won't record Double.NaN and thus make it null
+        return (getAnomalyGrade() != null && getAnomalyGrade() > 0) || getError() != null;
     }
 
     @Override
@@ -485,10 +519,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         out.writeOptionalString(error);
         if (entity != null) {
             out.writeBoolean(true);
-            out.writeVInt(entity.size());
-            for (Entity entityItem : entity) {
-                entityItem.writeTo(out);
-            }
+            entity.writeTo(out);
         } else {
             out.writeBoolean(false);
         }
@@ -500,5 +531,6 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         }
         out.writeInt(schemaVersion);
         out.writeOptionalString(taskId);
+        out.writeOptionalString(modelId);
     }
 }

--- a/src/main/java/org/opensearch/ad/transport/ADResultBulkTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/ADResultBulkTransportAction.java
@@ -116,14 +116,14 @@ public class ADResultBulkTransportAction extends HandledTransportAction<ADResult
             // exceed soft limit (60%) but smaller than hard limit (90%)
             float acceptProbability = 1 - indexingPressurePercent;
             for (AnomalyResult result : results) {
-                if (isHighPriorityRequest(result) || random.nextFloat() < acceptProbability) {
+                if (result.isHighPriority() || random.nextFloat() < acceptProbability) {
                     addResult(bulkRequest, result);
                 }
             }
         } else {
             // if exceeding hard limit, only index non-zero grade or error result
             for (AnomalyResult result : results) {
-                if (isHighPriorityRequest(result)) {
+                if (result.isHighPriority()) {
                     addResult(bulkRequest, result);
                 }
             }
@@ -137,10 +137,6 @@ public class ADResultBulkTransportAction extends HandledTransportAction<ADResult
         } else {
             listener.onResponse(new ADResultBulkResponse());
         }
-    }
-
-    private boolean isHighPriorityRequest(AnomalyResult result) {
-        return result.getAnomalyGrade() > 0 || result.getError() != null;
     }
 
     private void addResult(BulkRequest bulkRequest, AnomalyResult result) {

--- a/src/test/java/org/opensearch/ad/ratelimit/AbstractRateLimitingTest.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/AbstractRateLimitingTest.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.ratelimit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.opensearch.action.ActionListener;
+import org.opensearch.ad.AbstractADTest;
+import org.opensearch.ad.NodeStateManager;
+import org.opensearch.ad.TestHelpers;
+import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.threadpool.ThreadPool;
+
+public class AbstractRateLimitingTest extends AbstractADTest {
+    Clock clock;
+    AnomalyDetector detector;
+    NodeStateManager nodeStateManager;
+    String detectorId;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        clock = mock(Clock.class);
+        when(clock.instant()).thenReturn(Instant.now());
+
+        threadPool = mock(ThreadPool.class);
+        setUpADThreadPool(threadPool);
+
+        String field = "a";
+        detectorId = "123";
+        detector = TestHelpers.randomAnomalyDetectorUsingCategoryFields(detectorId, Arrays.asList(field));
+
+        nodeStateManager = mock(NodeStateManager.class);
+        doAnswer(invocation -> {
+            ActionListener<Optional<AnomalyDetector>> listener = invocation.getArgument(1);
+            listener.onResponse(Optional.of(detector));
+            return null;
+        }).when(nodeStateManager).getAnomalyDetector(any(String.class), any(ActionListener.class));
+    }
+}

--- a/src/test/java/org/opensearch/ad/ratelimit/CheckpointWriteWorkerTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/CheckpointWriteWorkerTests.java
@@ -1,0 +1,195 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.ratelimit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.ad.settings.AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_BATCH_SIZE;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.ad.AnomalyDetectorPlugin;
+import org.opensearch.ad.breaker.ADCircuitBreakerService;
+import org.opensearch.ad.constant.CommonName;
+import org.opensearch.ad.ml.CheckpointDao;
+import org.opensearch.ad.ml.EntityModel;
+import org.opensearch.ad.ml.ModelState;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.threadpool.ThreadPool;
+
+import test.org.opensearch.ad.util.MLUtil;
+import test.org.opensearch.ad.util.RandomModelStateConfig;
+
+public class CheckpointWriteWorkerTests extends AbstractRateLimitingTest {
+    CheckpointWriteWorker worker;
+
+    CheckpointDao checkpoint;
+    ClusterService clusterService;
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setUp() throws Exception {
+        super.setUp();
+        clusterService = mock(ClusterService.class);
+        ClusterSettings clusterSettings = new ClusterSettings(
+            Settings.EMPTY,
+            Collections
+                .unmodifiableSet(
+                    new HashSet<>(
+                        Arrays
+                            .asList(
+                                AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_MAX_HEAP_PERCENT,
+                                AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_CONCURRENCY,
+                                AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_BATCH_SIZE
+                            )
+                    )
+                )
+        );
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        checkpoint = mock(CheckpointDao.class);
+        Map<String, Object> checkpointMap = new HashMap<>();
+        checkpointMap.put(CheckpointDao.FIELD_MODEL, "a");
+        when(checkpoint.toIndexSource(any())).thenReturn(checkpointMap);
+
+        // Integer.MAX_VALUE makes a huge heap
+        worker = new CheckpointWriteWorker(
+            Integer.MAX_VALUE,
+            AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_SIZE_IN_BYTES,
+            AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_MAX_HEAP_PERCENT,
+            clusterService,
+            new Random(42),
+            mock(ADCircuitBreakerService.class),
+            threadPool,
+            Settings.EMPTY,
+            AnomalyDetectorSettings.MAX_QUEUED_TASKS_RATIO,
+            clock,
+            AnomalyDetectorSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
+            AnomalyDetectorSettings.LOW_SEGMENT_PRUNE_RATIO,
+            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
+            AnomalyDetectorSettings.QUEUE_MAINTENANCE,
+            checkpoint,
+            CommonName.CHECKPOINT_INDEX_NAME,
+            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            nodeStateManager,
+            AnomalyDetectorSettings.HOURLY_MAINTENANCE
+        );
+    }
+
+    public void testTriggerSave() {
+        ModelState<EntityModel> state = MLUtil.randomModelState(new RandomModelStateConfig.Builder().build());
+        worker.write(state, true, RequestPriority.MEDIUM);
+
+        verify(checkpoint, times(1)).batchWrite(any(), any());
+    }
+
+    /**
+     * Test that when more requests are coming than concurrency allowed, queues will be
+     * auto-flushed given enough time.
+     * @throws InterruptedException when thread.sleep gets interrupted
+     */
+    public void testTriggerAutoFlush() throws InterruptedException {
+        final CountDownLatch processingLatch = new CountDownLatch(1);
+
+        ExecutorService executorService = mock(ExecutorService.class);
+
+        ThreadPool mockThreadPool = mock(ThreadPool.class);
+        when(mockThreadPool.executor(AnomalyDetectorPlugin.AD_THREAD_POOL_NAME)).thenReturn(executorService);
+        doAnswer(invocation -> {
+            Runnable runnable = () -> {
+                try {
+                    processingLatch.await(100, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    LOG.error(e);
+                    assertTrue("Unexpected exception", false);
+                }
+                Runnable toInvoke = invocation.getArgument(0);
+                toInvoke.run();
+            };
+            // start a new thread so it won't block main test thread's execution
+            new Thread(runnable).start();
+            return null;
+        }).when(executorService).execute(any(Runnable.class));
+
+        // make sure permits are released and the next request probe starts
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(null);
+            return null;
+        }).when(checkpoint).batchWrite(any(), any());
+
+        // Integer.MAX_VALUE makes a huge heap
+        // create a worker to use mockThreadPool
+        worker = new CheckpointWriteWorker(
+            Integer.MAX_VALUE,
+            AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_SIZE_IN_BYTES,
+            AnomalyDetectorSettings.CHECKPOINT_WRITE_QUEUE_MAX_HEAP_PERCENT,
+            clusterService,
+            new Random(42),
+            mock(ADCircuitBreakerService.class),
+            mockThreadPool,
+            Settings.EMPTY,
+            AnomalyDetectorSettings.MAX_QUEUED_TASKS_RATIO,
+            clock,
+            AnomalyDetectorSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
+            AnomalyDetectorSettings.LOW_SEGMENT_PRUNE_RATIO,
+            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
+            AnomalyDetectorSettings.QUEUE_MAINTENANCE,
+            checkpoint,
+            CommonName.CHECKPOINT_INDEX_NAME,
+            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            nodeStateManager,
+            AnomalyDetectorSettings.HOURLY_MAINTENANCE
+        );
+
+        // our concurrency is 2, so first 2 requests cause two batches. And the
+        // remaining 1 stays in the queue until the 2 concurrent runs finish.
+        // first 2 batch account for one checkpoint.batchWrite; the remaining one
+        // calls checkpoint.batchWrite
+        // CHECKPOINT_WRITE_QUEUE_BATCH_SIZE is the largest batch size
+        int numberOfRequests = 2 * CHECKPOINT_WRITE_QUEUE_BATCH_SIZE.getDefault(Settings.EMPTY) + 1;
+        for (int i = 0; i < numberOfRequests; i++) {
+            ModelState<EntityModel> state = MLUtil.randomModelState(new RandomModelStateConfig.Builder().build());
+            worker.write(state, true, RequestPriority.MEDIUM);
+        }
+
+        // Here, we allow the first 2 pulling batch from queue operations to start.
+        processingLatch.countDown();
+
+        // wait until queues get emptied
+        int waitIntervals = 20;
+        while (!worker.isQueueEmpty() && waitIntervals-- >= 0) {
+            Thread.sleep(500);
+        }
+
+        assertTrue(worker.isQueueEmpty());
+        // of requests cause at least one batch.
+        verify(checkpoint, times(3)).batchWrite(any(), any());
+    }
+}

--- a/src/test/java/org/opensearch/ad/ratelimit/ResultWriteWorkerTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/ResultWriteWorkerTests.java
@@ -1,0 +1,175 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.ratelimit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.ad.breaker.ADCircuitBreakerService;
+import org.opensearch.ad.constant.CommonName;
+import org.opensearch.ad.constant.CommonValue;
+import org.opensearch.ad.model.AnomalyResult;
+import org.opensearch.ad.settings.AnomalyDetectorSettings;
+import org.opensearch.ad.transport.ADResultBulkRequest;
+import org.opensearch.ad.transport.ADResultBulkResponse;
+import org.opensearch.ad.transport.handler.MultiEntityResultHandler;
+import org.opensearch.ad.util.RestHandlerUtils;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.threadpool.ThreadPool;
+
+import com.google.common.collect.ImmutableList;
+
+public class ResultWriteWorkerTests extends AbstractRateLimitingTest {
+    ResultWriteWorker resultWriteQueue;
+    ClusterService clusterService;
+    MultiEntityResultHandler resultHandler;
+    AnomalyResult detectResult;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        clusterService = mock(ClusterService.class);
+        ClusterSettings clusterSettings = new ClusterSettings(
+            Settings.EMPTY,
+            Collections
+                .unmodifiableSet(
+                    new HashSet<>(
+                        Arrays
+                            .asList(
+                                AnomalyDetectorSettings.RESULT_WRITE_QUEUE_MAX_HEAP_PERCENT,
+                                AnomalyDetectorSettings.RESULT_WRITE_QUEUE_CONCURRENCY,
+                                AnomalyDetectorSettings.RESULT_WRITE_QUEUE_BATCH_SIZE
+                            )
+                    )
+                )
+        );
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        threadPool = mock(ThreadPool.class);
+        setUpADThreadPool(threadPool);
+
+        resultHandler = mock(MultiEntityResultHandler.class);
+
+        resultWriteQueue = new ResultWriteWorker(
+            Integer.MAX_VALUE,
+            AnomalyDetectorSettings.RESULT_WRITE_QUEUE_SIZE_IN_BYTES,
+            AnomalyDetectorSettings.RESULT_WRITE_QUEUE_MAX_HEAP_PERCENT,
+            clusterService,
+            new Random(42),
+            mock(ADCircuitBreakerService.class),
+            threadPool,
+            Settings.EMPTY,
+            AnomalyDetectorSettings.MAX_QUEUED_TASKS_RATIO,
+            clock,
+            AnomalyDetectorSettings.MEDIUM_SEGMENT_PRUNE_RATIO,
+            AnomalyDetectorSettings.LOW_SEGMENT_PRUNE_RATIO,
+            AnomalyDetectorSettings.MAINTENANCE_FREQ_CONSTANT,
+            AnomalyDetectorSettings.QUEUE_MAINTENANCE,
+            resultHandler,
+            xContentRegistry(),
+            nodeStateManager,
+            AnomalyDetectorSettings.HOURLY_MAINTENANCE
+        );
+
+        detectResult = new AnomalyResult(
+            randomAlphaOfLength(5),
+            randomAlphaOfLength(5),
+            0.8,
+            Double.NaN,
+            Double.NaN,
+            ImmutableList.of(),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            randomAlphaOfLength(5),
+            null,
+            null,
+            CommonValue.NO_SCHEMA_VERSION,
+            randomAlphaOfLength(5)
+        );
+
+    }
+
+    public void testRegular() {
+        List<IndexRequest> retryRequests = new ArrayList<>();
+
+        ADResultBulkResponse resp = new ADResultBulkResponse(retryRequests);
+
+        ADResultBulkRequest request = new ADResultBulkRequest();
+        request.add(detectResult);
+
+        doAnswer(invocation -> {
+            ActionListener<ADResultBulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(resp);
+            return null;
+        }).when(resultHandler).flush(any(), any());
+
+        resultWriteQueue.put(new ResultWriteRequest(Long.MAX_VALUE, detectorId, RequestPriority.MEDIUM, detectResult));
+
+        // the request results one flush
+        verify(resultHandler, times(1)).flush(any(), any());
+    }
+
+    public void testRetry() throws IOException {
+        List<IndexRequest> retryRequests = new ArrayList<>();
+        try (XContentBuilder builder = jsonBuilder()) {
+            IndexRequest indexRequest = new IndexRequest(CommonName.ANOMALY_RESULT_INDEX_ALIAS)
+                .source(detectResult.toXContent(builder, RestHandlerUtils.XCONTENT_WITH_TYPE));
+            retryRequests.add(indexRequest);
+        }
+
+        ADResultBulkResponse resp = new ADResultBulkResponse(retryRequests);
+
+        ADResultBulkRequest request = new ADResultBulkRequest();
+        request.add(detectResult);
+
+        final AtomicBoolean retried = new AtomicBoolean();
+        doAnswer(invocation -> {
+            ActionListener<ADResultBulkResponse> listener = invocation.getArgument(1);
+            if (retried.get()) {
+                listener.onResponse(new ADResultBulkResponse());
+            } else {
+                retried.set(true);
+                listener.onResponse(resp);
+            }
+            return null;
+        }).when(resultHandler).flush(any(), any());
+
+        resultWriteQueue.put(new ResultWriteRequest(Long.MAX_VALUE, detectorId, RequestPriority.MEDIUM, detectResult));
+
+        // one flush from the original request; and one due to retry
+        verify(resultHandler, times(2)).flush(any(), any());
+    }
+}


### PR DESCRIPTION
Note: as the code of writeQueue is not pushed to the upstream AD repo. I have to send a diff based on writeQueue in my fork.

### Description
First, I threw an exception instead of returning the exception through listener callback in CheckpointDao.  This can cause semaphores not released.   
Second, I didn’t check AnomalyResult.getAnomalyGrade() returns null or not, which can cause a null pointer exception.

Also, please ignore model id related changes in AnomalyResult.  The changes are included in a separate PR: https://github.com/opensearch-project/anomaly-detection/pull/75

Testing done:
1. Wrote unit tests for the above errors.
 
### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/85
 
### Check List
- [ X ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
