### PR TITLE
Refactor CheckpointWriteWorker

### DIFF
--- a/src/main/java/org/opensearch/ad/ratelimit/CheckpointWriteWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/CheckpointWriteWorker.java
@@ -151,7 +151,7 @@ public class CheckpointWriteWorker extends BatchWorker<CheckpointWriteRequest, B
      */
     public void write(ModelState<EntityModel> modelState, boolean forceWrite, RequestPriority priority) {
         Instant instant = modelState.getLastCheckpointTime();
-        if (!shoulSave(instant, forceWrite)) {
+        if (!shouldSave(instant, forceWrite)) {
             return;
         }
 
@@ -222,7 +222,7 @@ public class CheckpointWriteWorker extends BatchWorker<CheckpointWriteRequest, B
                 List<CheckpointWriteRequest> allRequests = new ArrayList<>();
                 for (ModelState<EntityModel> state : modelStates) {
                     Instant instant = state.getLastCheckpointTime();
-                    if (!shoulSave(instant, forceWrite)) {
+                    if (!shouldSave(instant, forceWrite)) {
                         continue;
                     }
 
@@ -270,7 +270,7 @@ public class CheckpointWriteWorker extends BatchWorker<CheckpointWriteRequest, B
      * @return true when forceWrite is true or we haven't saved checkpoint in the
      *  last checkpoint interval; false otherwise
      */
-    private boolean shoulSave(Instant lastCheckpointTIme, boolean forceWrite) {
+    private boolean shouldSave(Instant lastCheckpointTIme, boolean forceWrite) {
         return (lastCheckpointTIme != Instant.MIN && lastCheckpointTIme.plus(checkpointInterval).isBefore(clock.instant())) || forceWrite;
     }
 }


### PR DESCRIPTION
### Description
This PR refactors CheckpointWriteWorker
1. Extract the method shoulSave for code reuse.
2. Remove unnecessary exception handling in the write method as ConcurrentModificationException won’t happen when fetching a detector.

Testing done:
1. Added unit tests for the changed code.

### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/85
 
### Check List
- [ X ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).