### PR TITLE
Stats API bug fix

### DIFF
--- a/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/org/opensearch/ad/AnomalyDetectorPlugin.java
@@ -635,7 +635,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             .put(StatNames.AD_BATCH_TASK_FAILURE_COUNT.getName(), new ADStat<>(false, new CounterSupplier()))
             .build();
 
-        adStats = new ADStats(indexUtils, modelManager, stats);
+        adStats = new ADStats(stats);
 
         this.detectorStateHandler = new DetectionStateHandler(
             client,

--- a/src/main/java/org/opensearch/ad/EntityProfileRunner.java
+++ b/src/main/java/org/opensearch/ad/EntityProfileRunner.java
@@ -137,6 +137,12 @@ public class EntityProfileRunner extends AbstractProfileRunner {
 
     /**
      * Verify if the input entity exists or not in case of typos.
+     *
+     * If a user deletes the entity after job start, then we will not be able to
+     * get this entity in the index. For this case, we will not return a profile
+     * for this entity even if it's running on some data node. the entity's model
+     * will be deleted by another entity or by maintenance due to long inactivity.
+     *
      * @param entity Entity accessor
      * @param categoryFields category fields defined for a detector
      * @param detectorId Detector Id

--- a/src/main/java/org/opensearch/ad/model/ModelProfileOnNode.java
+++ b/src/main/java/org/opensearch/ad/model/ModelProfileOnNode.java
@@ -9,21 +9,6 @@
  * GitHub history for details.
  */
 
-/*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
 package org.opensearch.ad.model;
 
 import java.io.IOException;

--- a/src/main/java/org/opensearch/ad/stats/ADStats.java
+++ b/src/main/java/org/opensearch/ad/stats/ADStats.java
@@ -29,28 +29,19 @@ package org.opensearch.ad.stats;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.opensearch.ad.ml.ModelManager;
-import org.opensearch.ad.util.IndexUtils;
-
 /**
  * This class is the main entry-point for access to the stats that the AD plugin keeps track of.
  */
 public class ADStats {
 
-    private IndexUtils indexUtils;
-    private ModelManager modelManager;
     private Map<String, ADStat<?>> stats;
 
     /**
      * Constructor
      *
-     * @param indexUtils utility to get information about indices
-     * @param modelManager used to get information about which models are hosted on a particular node
      * @param stats Map of the stats that are to be kept
      */
-    public ADStats(IndexUtils indexUtils, ModelManager modelManager, Map<String, ADStat<?>> stats) {
-        this.indexUtils = indexUtils;
-        this.modelManager = modelManager;
+    public ADStats(Map<String, ADStat<?>> stats) {
         this.stats = stats;
     }
 

--- a/src/main/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeSupplier.java
+++ b/src/main/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeSupplier.java
@@ -27,6 +27,8 @@
 package org.opensearch.ad.stats.suppliers;
 
 import static org.opensearch.ad.ml.ModelState.MODEL_TYPE_KEY;
+import static org.opensearch.ad.ml.ModelState.LAST_CHECKPOINT_TIME_KEY;
+import static org.opensearch.ad.ml.ModelState.LAST_USED_TIME_KEY;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -53,7 +55,7 @@ public class ModelsOnNodeSupplier implements Supplier<List<Map<String, Object>>>
      * Set that contains the model stats that should be exposed.
      */
     public static Set<String> MODEL_STATE_STAT_KEYS = new HashSet<>(
-        Arrays.asList(CommonName.MODEL_ID_KEY, CommonName.DETECTOR_ID_KEY, MODEL_TYPE_KEY, CommonName.ENTITY_KEY)
+        Arrays.asList(CommonName.MODEL_ID_KEY, CommonName.DETECTOR_ID_KEY, MODEL_TYPE_KEY, CommonName.ENTITY_KEY, LAST_USED_TIME_KEY, LAST_CHECKPOINT_TIME_KEY)
     );
 
     /**

--- a/src/main/java/org/opensearch/ad/transport/ADStatsNodeResponse.java
+++ b/src/main/java/org/opensearch/ad/transport/ADStatsNodeResponse.java
@@ -100,6 +100,7 @@ public class ADStatsNodeResponse extends BaseNodeResponse implements ToXContentF
      * @return XContentBuilder
      * @throws IOException thrown by builder for invalid field
      */
+    @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         for (String stat : statsMap.keySet()) {
             builder.field(stat, statsMap.get(stat));

--- a/src/test/java/org/opensearch/ad/model/EntityTests.java
+++ b/src/test/java/org/opensearch/ad/model/EntityTests.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.ad.model;
+
+import java.util.TreeMap;
+
+import org.opensearch.ad.AbstractADTest;
+
+public class EntityTests extends AbstractADTest {
+    /**
+     * Test that toStrign has no random string, but only attributes
+     */
+    public void testToString() {
+        TreeMap<String, String> attributes = new TreeMap<>();
+        String name1 = "host";
+        String val1 = "server_2";
+        String name2 = "service";
+        String val2 = "app_4";
+        attributes.put(name1, val1);
+        attributes.put(name2, val2);
+        String detectorId = "detectorId";
+        Entity entity = Entity.createEntityFromOrderedMap(detectorId, attributes);
+        assertEquals("host=server_2,service=app_4", entity.toString());
+    }
+}

--- a/src/test/java/org/opensearch/ad/stats/ADStatsTests.java
+++ b/src/test/java/org/opensearch/ad/stats/ADStatsTests.java
@@ -125,7 +125,7 @@ public class ADStatsTests extends OpenSearchTestCase {
             }
         };
 
-        adStats = new ADStats(indexUtils, modelManager, statsMap);
+        adStats = new ADStats(statsMap);
     }
 
     @Test

--- a/src/test/java/org/opensearch/ad/transport/ADStatsNodesTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/ADStatsNodesTransportActionTests.java
@@ -105,7 +105,7 @@ public class ADStatsNodesTransportActionTests extends OpenSearchIntegTestCase {
             }
         };
 
-        adStats = new ADStats(indexUtils, modelManager, statsMap);
+        adStats = new ADStats(statsMap);
         JvmService jvmService = mock(JvmService.class);
         JvmStats jvmStats = mock(JvmStats.class);
         JvmStats.Mem mem = mock(JvmStats.Mem.class);

--- a/src/test/java/org/opensearch/ad/transport/AnomalyResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyResultTests.java
@@ -289,7 +289,7 @@ public class AnomalyResultTests extends AbstractADTest {
             }
         };
 
-        adStats = new ADStats(indexUtils, normalModelManager, statsMap);
+        adStats = new ADStats(statsMap);
 
         doAnswer(invocation -> {
             Object[] args = invocation.getArguments();

--- a/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/MultiEntityResultTests.java
@@ -105,7 +105,7 @@ import org.opensearch.transport.TransportService;
 import test.org.opensearch.ad.util.MLUtil;
 import test.org.opensearch.ad.util.RandomModelStateConfig;
 
-public class MultientityResultTests extends AbstractADTest {
+public class MultiEntityResultTests extends AbstractADTest {
     private AnomalyResultTransportAction action;
     private AnomalyResultRequest request;
     private TransportInterceptor entityResultInterceptor;
@@ -215,7 +215,7 @@ public class MultientityResultTests extends AbstractADTest {
                 put(StatNames.AD_HC_EXECUTE_FAIL_COUNT.getName(), new ADStat<>(false, new CounterSupplier()));
             }
         };
-        adStats = new ADStats(indexUtils, normalModelManager, statsMap);
+        adStats = new ADStats(statsMap);
 
         searchFeatureDao = mock(SearchFeatureDao.class);
 

--- a/src/test/java/test/org/opensearch/ad/util/JsonDeserializer.java
+++ b/src/test/java/test/org/opensearch/ad/util/JsonDeserializer.java
@@ -408,6 +408,25 @@ public class JsonDeserializer {
     }
 
     /**
+     * Search a float number inside a JSON string matching the input path
+     * expression
+     *
+     * @param jsonString an encoded JSON string
+     * @param paths      path fragments
+     * @return the matching double number
+     * @throws JsonPathNotFoundException if json path is invalid
+     * @throws IOException               if the underlying input source has problems
+     *                                   during parsing
+     */
+    public static double getFloatValue(String jsonString, String... paths) throws JsonPathNotFoundException, IOException {
+        JsonElement jsonNode = getChildNode(jsonString, paths);
+        if (jsonNode != null) {
+            return jsonNode.getAsFloat();
+        }
+        throw new JsonPathNotFoundException();
+    }
+
+    /**
      * Search an int number inside a JSON string matching the input path expression
      *
      * @param jsonString an encoded JSON string


### PR DESCRIPTION
### Description

The stats API broadcasts requests to all nodes and renders node responses using toXContent. For the local node, the stats API's calls toXContent on the node response directly. For remote node, the coordinating node gets a serialized content from

ADStatsNodeResponse.writeTo, deserializes the content and renders the result using toXContent. ADStatsNodeResponse.writeTo uses StreamOutput::writeGenericValue that only recognizes built-in types (e.g., String or primitive types). It throws exceptions for types such as java.time.Instant and Entity. This PR fixes the bug by converting non-built-in types to built-in types in node stats response.

This PR also removes model id from Entity.toString as it is random across different runs and keeps only attributes.  This can help locate the same node in hash ring.

This PR also removes unused fields in ADStats.

Testing done:
* Verified stats API response on a multi-node cluster for a multiple-category field detector.
* Added unit tests.

### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/87
 
### Check List
- [ X ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).