### PR TITLE
Calculate requests to prune in RateLimitedQueue.prune

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -327,7 +327,6 @@ List<String> jacocoExclusions = [
         'org.opensearch.ad.indices.AnomalyDetectionIndices',
         'org.opensearch.ad.transport.handler.MultiEntityResultHandler',
         'org.opensearch.ad.util.ThrowingSupplierWrapper',
-        //'org.opensearch.ad.ratelimit.*',
         'org.opensearch.ad.transport.EntityResultTransportAction',
         'org.opensearch.ad.transport.EntityResultTransportAction.*',
         'org.opensearch.ad.transport.AnomalyResultTransportAction.*',

--- a/src/main/java/org/opensearch/ad/ratelimit/CheckpointReadWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/CheckpointReadWorker.java
@@ -69,6 +69,7 @@ import org.opensearch.threadpool.ThreadPool;
  */
 public class CheckpointReadWorker extends BatchWorker<EntityFeatureRequest, MultiGetRequest, MultiGetResponse> {
     private static final Logger LOG = LogManager.getLogger(CheckpointReadWorker.class);
+    public static final String WORKER_NAME = "checkpoint-read";
     private final ModelManager modelManager;
     private final CheckpointDao checkpointDao;
     private final EntityColdStartWorker entityColdStartQueue;
@@ -103,7 +104,7 @@ public class CheckpointReadWorker extends BatchWorker<EntityFeatureRequest, Mult
         CheckpointWriteWorker checkpointWriteQueue
     ) {
         super(
-            "checkpoint-read",
+            WORKER_NAME,
             heapSizeInBytes,
             singleRequestSizeInBytes,
             maxHeapPercentForQueueSetting,

--- a/src/main/java/org/opensearch/ad/ratelimit/CheckpointWriteWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/CheckpointWriteWorker.java
@@ -46,6 +46,7 @@ import org.opensearch.threadpool.ThreadPool;
 
 public class CheckpointWriteWorker extends BatchWorker<CheckpointWriteRequest, BulkRequest, BulkResponse> {
     private static final Logger LOG = LogManager.getLogger(CheckpointWriteWorker.class);
+    public static final String WORKER_NAME = "checkpoint-write";
 
     private final CheckpointDao checkpoint;
     private final String indexName;
@@ -73,7 +74,7 @@ public class CheckpointWriteWorker extends BatchWorker<CheckpointWriteRequest, B
         Duration stateTtl
     ) {
         super(
-            "checkpoint-write",
+            WORKER_NAME,
             heapSizeInBytes,
             singleRequestSizeInBytes,
             maxHeapPercentForQueueSetting,

--- a/src/main/java/org/opensearch/ad/ratelimit/ColdEntityWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/ColdEntityWorker.java
@@ -49,6 +49,7 @@ import org.opensearch.threadpool.ThreadPool;
  */
 public class ColdEntityWorker extends RateLimitedRequestWorker<EntityFeatureRequest> {
     private static final Logger LOG = LogManager.getLogger(ColdEntityWorker.class);
+    public static final String WORKER_NAME = "cold-entity";
 
     private volatile int batchSize;
     private final CheckpointReadWorker checkpointReadQueue;
@@ -75,7 +76,7 @@ public class ColdEntityWorker extends RateLimitedRequestWorker<EntityFeatureRequ
         NodeStateManager nodeStateManager
     ) {
         super(
-            "cold-entity",
+            WORKER_NAME,
             heapSizeInBytes,
             singleRequestSizeInBytes,
             maxHeapPercentForQueueSetting,

--- a/src/main/java/org/opensearch/ad/ratelimit/EntityColdStartWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/EntityColdStartWorker.java
@@ -46,6 +46,7 @@ import org.opensearch.threadpool.ThreadPool;
  */
 public class EntityColdStartWorker extends SingleRequestWorker<EntityRequest> {
     private static final Logger LOG = LogManager.getLogger(EntityColdStartWorker.class);
+    public static final String WORKER_NAME = "cold-start";
 
     private final EntityColdStarter entityColdStarter;
 
@@ -69,7 +70,7 @@ public class EntityColdStartWorker extends SingleRequestWorker<EntityRequest> {
         NodeStateManager nodeStateManager
     ) {
         super(
-            "cold-start",
+            WORKER_NAME,
             heapSizeInBytes,
             singleRequestSizeInBytes,
             maxHeapPercentForQueueSetting,

--- a/src/main/java/org/opensearch/ad/ratelimit/ResultWriteWorker.java
+++ b/src/main/java/org/opensearch/ad/ratelimit/ResultWriteWorker.java
@@ -47,6 +47,7 @@ import org.opensearch.threadpool.ThreadPool;
 
 public class ResultWriteWorker extends BatchWorker<ResultWriteRequest, ADResultBulkRequest, ADResultBulkResponse> {
     private static final Logger LOG = LogManager.getLogger(ResultWriteWorker.class);
+    public static final String WORKER_NAME = "result-write";
 
     private final MultiEntityResultHandler resultHandler;
     private NamedXContentRegistry xContentRegistry;
@@ -72,7 +73,7 @@ public class ResultWriteWorker extends BatchWorker<ResultWriteRequest, ADResultB
         Duration stateTtl
     ) {
         super(
-            "result-write",
+            WORKER_NAME,
             heapSizeInBytes,
             singleRequestSizeInBytes,
             maxHeapPercentForQueueSetting,

--- a/src/main/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeSupplier.java
+++ b/src/main/java/org/opensearch/ad/stats/suppliers/ModelsOnNodeSupplier.java
@@ -26,9 +26,9 @@
 
 package org.opensearch.ad.stats.suppliers;
 
-import static org.opensearch.ad.ml.ModelState.MODEL_TYPE_KEY;
 import static org.opensearch.ad.ml.ModelState.LAST_CHECKPOINT_TIME_KEY;
 import static org.opensearch.ad.ml.ModelState.LAST_USED_TIME_KEY;
+import static org.opensearch.ad.ml.ModelState.MODEL_TYPE_KEY;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -55,7 +55,15 @@ public class ModelsOnNodeSupplier implements Supplier<List<Map<String, Object>>>
      * Set that contains the model stats that should be exposed.
      */
     public static Set<String> MODEL_STATE_STAT_KEYS = new HashSet<>(
-        Arrays.asList(CommonName.MODEL_ID_KEY, CommonName.DETECTOR_ID_KEY, MODEL_TYPE_KEY, CommonName.ENTITY_KEY, LAST_USED_TIME_KEY, LAST_CHECKPOINT_TIME_KEY)
+        Arrays
+            .asList(
+                CommonName.MODEL_ID_KEY,
+                CommonName.DETECTOR_ID_KEY,
+                MODEL_TYPE_KEY,
+                CommonName.ENTITY_KEY,
+                LAST_USED_TIME_KEY,
+                LAST_CHECKPOINT_TIME_KEY
+            )
     );
 
     /**

--- a/src/test/java/org/opensearch/ad/ratelimit/AbstractRateLimitingTest.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/AbstractRateLimitingTest.java
@@ -35,7 +35,7 @@ public class AbstractRateLimitingTest extends AbstractADTest {
     NodeStateManager nodeStateManager;
     String detectorId;
     String categoryField;
-    Entity entity, entity2;
+    Entity entity, entity2, entity3;
 
     @SuppressWarnings("unchecked")
     @Override
@@ -61,5 +61,6 @@ public class AbstractRateLimitingTest extends AbstractADTest {
 
         entity = Entity.createSingleAttributeEntity(detectorId, categoryField, "value");
         entity2 = Entity.createSingleAttributeEntity(detectorId, categoryField, "value2");
+        entity3 = Entity.createSingleAttributeEntity(detectorId, categoryField, "value3");
     }
 }

--- a/src/test/java/org/opensearch/ad/ratelimit/CheckpointReadWorkerTests.java
+++ b/src/test/java/org/opensearch/ad/ratelimit/CheckpointReadWorkerTests.java
@@ -672,10 +672,7 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
         assertTrue(!worker.isQueueEmpty());
 
         // one request per batch
-        Settings newSettings = Settings
-            .builder()
-            .put(AnomalyDetectorSettings.CHECKPOINT_READ_QUEUE_BATCH_SIZE.getKey(), "1")
-            .build();
+        Settings newSettings = Settings.builder().put(AnomalyDetectorSettings.CHECKPOINT_READ_QUEUE_BATCH_SIZE.getKey(), "1").build();
         Settings.Builder target = Settings.builder();
         clusterSettings.updateDynamicSettings(newSettings, target, Settings.builder(), "test");
         clusterSettings.applySettings(target.build());
@@ -714,5 +711,19 @@ public class CheckpointReadWorkerTests extends AbstractRateLimitingTest {
 
         // two requests in the queue trigger two batches
         verify(checkpoint, times(2)).batchRead(any(), any());
+    }
+
+    public void testChangePriority() {
+        assertEquals(RequestPriority.MEDIUM, request.getPriority());
+        RequestPriority newPriority = RequestPriority.HIGH;
+        request.setPriority(newPriority);
+        assertEquals(newPriority, request.getPriority());
+    }
+
+    public void testDetectorId() {
+        assertEquals(detectorId, request.getDetectorId());
+        String newDetectorId = "456";
+        request.setDetectorId(newDetectorId);
+        assertEquals(newDetectorId, request.getDetectorId());
     }
 }


### PR DESCRIPTION
### Description

Currently, I prune overflow requests in multiple loop iterations. This PR calculates how many requests we should prune directly to avoid this while loop.

This PR also:
*Put the hardcoded worker name to variables for code reuse.
*Fixed a bug in RateLimitedRequestWorker’s constructor that doesn’t assign variables in the setting update consumer.

Testing done:
* added unit tests for related changes.

### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/66
 
### Check List
- [ X ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).