### PR TITLE
Cache fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -342,7 +342,6 @@ List<String> jacocoExclusions = [
         'org.opensearch.ad.feature.ScriptMaker',
         'org.opensearch.ad.ml.EntityModel',
         'org.opensearch.ad.caching.PriorityCache',
-        'org.opensearch.ad.ml.CheckpointDao',
 ]
 
 jacocoTestCoverageVerification {

--- a/src/main/java/org/opensearch/ad/caching/CacheBuffer.java
+++ b/src/main/java/org/opensearch/ad/caching/CacheBuffer.java
@@ -297,8 +297,8 @@ public class CacheBuffer implements ExpiringState {
         if (items.isEmpty()) {
             return false;
         }
-        Entry<String, Float> minPriorityItem = priorityTracker.getMinimumPriority();
-        return minPriorityItem != null && priority > minPriorityItem.getValue();
+        Optional<Entry<String, Float>> minPriorityItem = priorityTracker.getMinimumPriority();
+        return minPriorityItem.isPresent() && priority > minPriorityItem.get().getValue();
     }
 
     /**

--- a/src/main/java/org/opensearch/ad/caching/PriorityTracker.java
+++ b/src/main/java/org/opensearch/ad/caching/PriorityTracker.java
@@ -184,28 +184,40 @@ public class PriorityTracker {
     /**
      * Get the minimum priority entity and compute its scaled priority.
      * Used to compare entity priorities among detectors.
-     * @return the minimum priority entity's ID and scaled priority
+     * @return the minimum priority entity's ID and scaled priority or Optional.empty
+     *  if the priority list is empty
      */
-    public Entry<String, Float> getMinimumScaledPriority() {
+    public Optional<Entry<String, Float>> getMinimumScaledPriority() {
+        if (priorityList.isEmpty()) {
+            return Optional.empty();
+        }
         PriorityNode smallest = priorityList.first();
-        return new SimpleImmutableEntry<>(smallest.key, getScaledPriority(smallest.priority));
+        return Optional.of(new SimpleImmutableEntry<>(smallest.key, getScaledPriority(smallest.priority)));
     }
 
     /**
      * Get the minimum priority entity and compute its scaled priority.
      * Used to compare entity priorities within the same detector.
-     * @return the minimum priority entity's ID and scaled priority
+     * @return the minimum priority entity's ID and scaled priority or Optional.empty
+     *  if the priority list is empty
      */
-    public Entry<String, Float> getMinimumPriority() {
+    public Optional<Entry<String, Float>> getMinimumPriority() {
+        if (priorityList.isEmpty()) {
+            return Optional.empty();
+        }
         PriorityNode smallest = priorityList.first();
-        return new SimpleImmutableEntry<>(smallest.key, smallest.priority);
+        return Optional.of(new SimpleImmutableEntry<>(smallest.key, smallest.priority));
     }
 
     /**
      *
-     * @return the minimum priority entity's Id
+     * @return the minimum priority entity's Id or Optional.empty
+     *  if the priority list is empty
      */
     public Optional<String> getMinimumPriorityEntityId() {
+        if (priorityList.isEmpty()) {
+            return Optional.empty();
+        }
         return Optional.of(priorityList).map(list -> list.first()).map(node -> node.key);
     }
 
@@ -214,6 +226,9 @@ public class PriorityTracker {
     * @return Get maximum priority entity's Id
     */
     public Optional<String> getHighestPriorityEntityId() {
+        if (priorityList.isEmpty()) {
+            return Optional.empty();
+        }
         return Optional.of(priorityList).map(list -> list.last()).map(node -> node.key);
     }
 

--- a/src/test/java/org/opensearch/ad/caching/AbstractCacheTest.java
+++ b/src/test/java/org/opensearch/ad/caching/AbstractCacheTest.java
@@ -50,11 +50,6 @@ public class AbstractCacheTest extends AbstractADTest {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        modelId1 = "1";
-        modelId2 = "2";
-        modelId3 = "3";
-        modelId4 = "4";
-
         detector = mock(AnomalyDetector.class);
         detectorId = "123";
         when(detector.getDetectorId()).thenReturn(detectorId);
@@ -66,6 +61,10 @@ public class AbstractCacheTest extends AbstractADTest {
         entity2 = Entity.createSingleAttributeEntity(detectorId, "attributeName1", "attributeVal2");
         entity3 = Entity.createSingleAttributeEntity(detectorId, "attributeName1", "attributeVal3");
         entity4 = Entity.createSingleAttributeEntity(detectorId, "attributeName1", "attributeVal4");
+        modelId1 = entity1.getModelId(detectorId).get();
+        modelId2 = entity2.getModelId(detectorId).get();
+        modelId3 = entity3.getModelId(detectorId).get();
+        modelId4 = entity4.getModelId(detectorId).get();
 
         clock = mock(Clock.class);
         when(clock.instant()).thenReturn(Instant.now());

--- a/src/test/java/org/opensearch/ad/caching/CacheBufferTests.java
+++ b/src/test/java/org/opensearch/ad/caching/CacheBufferTests.java
@@ -34,6 +34,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Optional;
 
 import org.mockito.ArgumentCaptor;
 import org.opensearch.ad.MemoryTracker;
@@ -57,14 +58,14 @@ public class CacheBufferTests extends AbstractCacheTest {
         cacheBuffer.put(modelId1, modelState1);
         cacheBuffer.put(modelId2, modelState2);
         assertEquals(modelId1, cacheBuffer.get(modelId1).getModelId());
-        Entry<String, Float> removalCandidate = cacheBuffer.getPriorityTracker().getMinimumScaledPriority();
-        assertEquals(modelId2, removalCandidate.getKey());
+        Optional<Entry<String, Float>> removalCandidate = cacheBuffer.getPriorityTracker().getMinimumScaledPriority();
+        assertEquals(modelId2, removalCandidate.get().getKey());
         cacheBuffer.remove();
         cacheBuffer.put(modelId3, modelState3);
         assertEquals(null, cacheBuffer.get(modelId2));
         assertEquals(modelId3, cacheBuffer.get(modelId3).getModelId());
         removalCandidate = cacheBuffer.getPriorityTracker().getMinimumScaledPriority();
-        assertEquals(modelId1, removalCandidate.getKey());
+        assertEquals(modelId1, removalCandidate.get().getKey());
         cacheBuffer.remove(modelId1);
         assertEquals(null, cacheBuffer.get(modelId1));
         cacheBuffer.put(modelId4, modelState4);

--- a/src/test/java/org/opensearch/ad/caching/PriorityTrackerTests.java
+++ b/src/test/java/org/opensearch/ad/caching/PriorityTrackerTests.java
@@ -81,18 +81,18 @@ public class PriorityTrackerTests extends OpenSearchTestCase {
     public void testOverflow() {
         when(clock.instant()).thenReturn(now);
         tracker.updatePriority(entity1);
-        float priority1 = tracker.getMinimumScaledPriority().getValue();
+        float priority1 = tracker.getMinimumScaledPriority().get().getValue();
 
         // when(clock.instant()).thenReturn(now.plusSeconds(60L));
         tracker.updatePriority(entity1);
-        float priority2 = tracker.getMinimumScaledPriority().getValue();
+        float priority2 = tracker.getMinimumScaledPriority().get().getValue();
         // we incremented the priority
         assertTrue("The following is expected: " + priority2 + " > " + priority1, priority2 > priority1);
 
         when(clock.instant()).thenReturn(now.plus(3, ChronoUnit.DAYS));
         tracker.updatePriority(entity1);
         // overflow happens, we use increment as the new priority
-        assertEquals(0, tracker.getMinimumScaledPriority().getValue().floatValue(), 0.001);
+        assertEquals(0, tracker.getMinimumScaledPriority().get().getValue().floatValue(), 0.001);
     }
 
     public void testTooManyEntities() {
@@ -104,5 +104,12 @@ public class PriorityTrackerTests extends OpenSearchTestCase {
         tracker.updatePriority(entity2);
         // one entity is kicked out due to the size limit is reached.
         assertEquals(2, tracker.size());
+    }
+
+    public void testEmptyTracker() {
+        assertTrue(!tracker.getMinimumScaledPriority().isPresent());
+        assertTrue(!tracker.getMinimumPriority().isPresent());
+        assertTrue(!tracker.getMinimumPriorityEntityId().isPresent());
+        assertTrue(!tracker.getHighestPriorityEntityId().isPresent());
     }
 }


### PR DESCRIPTION
### Description

Fix bug in PriorityTracker

PriorityTracker uses a ConcurrentSkipListSet to record priorities/frequencies of entities. I didn’t realize that ConcurrentSkipListSet.first() and ConcurrentSkipListSet.last() method throws exceptions when the set is empty. This PR adds an empty check.

Also, we want PriorityCache.selectUpdateCandidate to be side-effect free. Thus, this PR replaces the computeBufferIfAbsent method call with activeEnities.get as computeBufferIfAbsent has side effects by creating a CacheBuffer.

Testing done:
* created unit tests for related changes.

### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/119
 
### Check List
- [ X ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).