### PR TITLE
Fix bug on EndRunException

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -329,7 +329,7 @@ List<String> jacocoExclusions = [
         'org.opensearch.ad.util.ThrowingSupplierWrapper',
         'org.opensearch.ad.transport.EntityResultTransportAction',
         'org.opensearch.ad.transport.EntityResultTransportAction.*',
-        'org.opensearch.ad.transport.AnomalyResultTransportAction.*',
+        //'org.opensearch.ad.transport.AnomalyResultTransportAction.*',
         'org.opensearch.ad.transport.ProfileNodeResponse',
         'org.opensearch.ad.transport.ADResultBulkResponse',
         'org.opensearch.ad.transport.AggregationType',
@@ -338,10 +338,9 @@ List<String> jacocoExclusions = [
         'org.opensearch.ad.util.BulkUtil',
         'org.opensearch.ad.util.ExceptionUtil',
         'org.opensearch.ad.feature.SearchFeatureDao',
-        'org.opensearch.ad.feature.CompositeRetriever.*',
+        //'org.opensearch.ad.feature.CompositeRetriever.*',
         'org.opensearch.ad.feature.ScriptMaker',
         'org.opensearch.ad.ml.EntityModel',
-        'org.opensearch.ad.caching.PriorityCache',
 ]
 
 jacocoTestCoverageVerification {

--- a/src/main/java/org/opensearch/ad/transport/EntityResultTransportAction.java
+++ b/src/main/java/org/opensearch/ad/transport/EntityResultTransportAction.java
@@ -52,7 +52,6 @@ import org.opensearch.ad.common.exception.LimitExceededException;
 import org.opensearch.ad.constant.CommonErrorMessages;
 import org.opensearch.ad.indices.ADIndex;
 import org.opensearch.ad.indices.AnomalyDetectionIndices;
-import org.opensearch.ad.ml.EntityColdStarter;
 import org.opensearch.ad.ml.EntityModel;
 import org.opensearch.ad.ml.ModelManager;
 import org.opensearch.ad.ml.ModelState;
@@ -102,7 +101,6 @@ public class EntityResultTransportAction extends HandledTransportAction<EntityRe
     private AnomalyDetectionIndices indexUtil;
     private ResultWriteWorker resultWriteQueue;
     private CheckpointReadWorker checkpointReadQueue;
-    private EntityColdStarter coldStarter;
     private ColdEntityWorker coldEntityQueue;
     private ThreadPool threadPool;
 
@@ -117,7 +115,6 @@ public class EntityResultTransportAction extends HandledTransportAction<EntityRe
         AnomalyDetectionIndices indexUtil,
         ResultWriteWorker resultWriteQueue,
         CheckpointReadWorker checkpointReadQueue,
-        EntityColdStarter coldStarer,
         ColdEntityWorker coldEntityQueue,
         ThreadPool threadPool
     ) {
@@ -129,7 +126,6 @@ public class EntityResultTransportAction extends HandledTransportAction<EntityRe
         this.indexUtil = indexUtil;
         this.resultWriteQueue = resultWriteQueue;
         this.checkpointReadQueue = checkpointReadQueue;
-        this.coldStarter = coldStarer;
         this.coldEntityQueue = coldEntityQueue;
         this.threadPool = threadPool;
     }

--- a/src/test/java/org/opensearch/ad/transport/AnomalyResultTests.java
+++ b/src/test/java/org/opensearch/ad/transport/AnomalyResultTests.java
@@ -52,7 +52,6 @@ import static org.opensearch.ad.TestHelpers.createIndexBlockedState;
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
 
 import java.io.IOException;
-import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -106,9 +105,6 @@ import org.opensearch.ad.stats.ADStat;
 import org.opensearch.ad.stats.ADStats;
 import org.opensearch.ad.stats.StatNames;
 import org.opensearch.ad.stats.suppliers.CounterSupplier;
-import org.opensearch.ad.util.ClientUtil;
-import org.opensearch.ad.util.IndexUtils;
-import org.opensearch.ad.util.Throttler;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.ClusterState;
@@ -274,11 +270,6 @@ public class AnomalyResultTests extends AbstractADTest {
         }).when(client).index(any(), any());
 
         indexNameResolver = new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY));
-        Clock clock = mock(Clock.class);
-        Throttler throttler = new Throttler(clock);
-        ThreadPool threadpool = mock(ThreadPool.class);
-        ClientUtil clientUtil = new ClientUtil(Settings.EMPTY, client, throttler, threadpool);
-        IndexUtils indexUtils = new IndexUtils(client, clientUtil, clusterService, indexNameResolver);
 
         Map<String, ADStat<?>> statsMap = new HashMap<String, ADStat<?>>() {
             {

--- a/src/test/java/org/opensearch/ad/transport/EntityResultTransportActionTests.java
+++ b/src/test/java/org/opensearch/ad/transport/EntityResultTransportActionTests.java
@@ -256,7 +256,6 @@ public class EntityResultTransportActionTests extends AbstractADTest {
             indexUtil,
             resultWriteQueue,
             checkpointReadQueue,
-            coldStarter,
             coldEntityQueue,
             threadPool
         );


### PR DESCRIPTION
### Description

We throw an EndRunException (endNow = true) whenever there is an SearchPhaseExecutionException. EndRunException (endNow = true)  stops a detector immediately. But these query exceptions can happen during the starting phase of the OpenSearch process. To confirm the EndRunException is not a false positive, this PR fixed that by setting the stopNow parameter of these EndRunException to false.

This PR also removes an unused field in EntityResultTransportAction.

Testing done:
* created unit tests for related changes.

### Issues Resolved
https://github.com/opensearch-project/anomaly-detection/issues/120
 
### Check List
- [ X ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).